### PR TITLE
Bugfix | Exporting to PDF without Internet Connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,7 @@ Actual result: The changes made in step 2. are reflected in `my_file.html`.
 
 ## Release Notes
 
-### 1.0.0
-
-Initial release of Markdown PDF Plus.
+See the [changelog](CHANGELOG.md).
 
 ## Third-Party Software
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@types/mocha": "^10.0.1",
     "@types/node": "16.x",
     "@types/sinon": "^10.0.15",
-    "@types/vscode": "^1.78.0",
+    "@types/vscode": "^1.76.0",
     "@typescript-eslint/eslint-plugin": "^5.59.1",
     "@typescript-eslint/parser": "^5.59.1",
     "@vscode/test-electron": "^2.3.0",

--- a/src/commands/export.pdf.ts
+++ b/src/commands/export.pdf.ts
@@ -9,6 +9,8 @@ import exportHtml from "./export.html";
 import StylesheetInfo from "../interfaces/stylesheetInfo";
 import { isMdDocument } from "../util/general";
 
+let conditionalUIMessage = "";
+
 const exportPdf = async (): Promise<boolean> => {
   const config: vscode.WorkspaceConfiguration =
     vscode.workspace.getConfiguration("markdown-pdf-plus");
@@ -58,7 +60,8 @@ const exportPdf = async (): Promise<boolean> => {
       fs.unlink(inputHtmlPath, () => {
         console.log("Temporary HTML file deleted.");
       });
-      vscode.window.showInformationMessage(UIMessages.exportToPdfSucceeded);
+
+      vscode.window.showInformationMessage(conditionalUIMessage);
       return true;
     } else {
       fs.unlink(inputHtmlPath, () => {
@@ -115,7 +118,12 @@ const addExternalStylesheetsToPage = async (htmlFilePath: string, page: Page): P
 
   for (const stylesheet of stylesheets) {
     if (stylesheet.isExternal) {
-      await page.addStyleTag({ url: stylesheet.path });
+      try {
+        await page.addStyleTag({ url: stylesheet.path });
+        conditionalUIMessage = UIMessages.exportToPdfSucceeded;
+      } catch (error) {
+        conditionalUIMessage = UIMessages.exportToPdfSucceededExternalCssFailed;
+      }
     } else {
       const stylesheetContent = await fs.promises.readFile(stylesheet.path, "utf8");
       await page.addStyleTag({ content: stylesheetContent });

--- a/src/commands/export.pdf.ts
+++ b/src/commands/export.pdf.ts
@@ -116,11 +116,11 @@ const addExternalStylesheetsToPage = async (htmlFilePath: string, page: Page): P
   const fileContent = await fs.promises.readFile(htmlFilePath, "utf8");
   const stylesheets = extractStylesheetsFromHtml(fileContent, htmlFilePath);
 
+  conditionalUIMessage = UIMessages.exportToPdfSucceeded;
   for (const stylesheet of stylesheets) {
     if (stylesheet.isExternal) {
       try {
         await page.addStyleTag({ url: stylesheet.path });
-        conditionalUIMessage = UIMessages.exportToPdfSucceeded;
       } catch (error) {
         conditionalUIMessage = UIMessages.exportToPdfSucceededExternalCssFailed;
       }

--- a/src/constants/uiMessages.ts
+++ b/src/constants/uiMessages.ts
@@ -12,6 +12,7 @@ const enum UIMessages {
   renamingOrMovingHtmlFailed = "Exported HTML could not be renamed and/or moved.",
   exportToPdfFailed = "Exporting file to PDF failed.",
   exportToPdfSucceeded = "File successfully exported to PDF.",
+  exportToPdfSucceededExternalCssFailed = "File successfully exported to PDF, but one or more external stylesheets could not be retrieved.",
 }
 
 export default UIMessages;

--- a/yarn.lock
+++ b/yarn.lock
@@ -222,10 +222,10 @@
   resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz#bf2e02a3dbd4aecaf95942ecd99b7402e03fad5e"
   integrity sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==
 
-"@types/vscode@^1.78.0":
-  version "1.78.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.78.0.tgz#b5600abce8855cf21fb32d0857bcd084b1f83069"
-  integrity sha512-LJZIJpPvKJ0HVQDqfOy6W4sNKUBBwyDu1Bs8chHBZOe9MNuKTJtidgZ2bqjhmmWpUb0TIIqv47BFUcVmAsgaVA==
+"@types/vscode@^1.76.0":
+  version "1.81.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.81.0.tgz#c27228dd063002e0e00611be70b0497beaa24d39"
+  integrity sha512-YIaCwpT+O2E7WOMq0eCgBEABE++SX3Yl/O02GoMIF2DO3qAtvw7m6BXFYsxnc6XyzwZgh6/s/UG78LSSombl2w==
 
 "@types/yauzl@^2.9.1":
   version "2.10.0"


### PR DESCRIPTION
# What was the bug?

**Given** a user is exporting HTML to PDF (whether directly from HTML or intermediately from Markdown),
**and** the HTML file refers to at least one external style sheet (always the case for `.md` to `.pdf`)
**and** the user does not have an internet connection,

*Expected  result:*
**then** the HTML should be exported to PDF, and the user should be notified that one or more external style sheets could not be loaded.

*Actual result:*
**then** exporting to PDF fails.

# How did you fix it?
Surrounded in a try-catch the call to Puppeteer's `Page.addStyleTag()`. If an error is caught, then exporting proceeds but without the style sheet that caused the call to fail, and the user is notified of its absence, granted the rest of the exporting is successful.