### PR TITLE
Bugfix | Exported PDFs Properly Display Fenced Codeblocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,3 +44,7 @@ All notable changes to the "markdown-pdf-plus" extension will be documented in t
 # [1.2.3]
 
 - Background images are supported.
+- Broke fenced code blocks.
+
+# [1.2.4]
+- Fixed fenced code blocks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to the "markdown-pdf-plus" extension will be documented in t
 - [Mermaid](https://mermaid.js.org/) is supported.
 - Updated the README to include page-customization details.
 
-# [1.2.1]
+## [1.2.1]
 
 - ~~Background images are supported.~~
 - ~~Fixed the bug where HTML files get overwritten when exporting PDFs.~~
@@ -36,15 +36,16 @@ All notable changes to the "markdown-pdf-plus" extension will be documented in t
 - ~~Exporting files to a specified directory now works even with referenced assets in the source file (e.g., CSS files and images).~~
 - Broke the extension.
 
-# [1.2.2]
+## [1.2.2]
 
 - ~~Background images are supported.~~
 - Still broken.
 
-# [1.2.3]
+## [1.2.3]
 
 - Background images are supported.
 - Broke fenced code blocks.
 
-# [1.2.4]
+## [1.2.4]
+
 - Fixed fenced code blocks.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-pdf-plus",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "publisher": "tom-latham",
   "engines": {
     "vscode": "^1.75.0"

--- a/src/commands/export.pdf.ts
+++ b/src/commands/export.pdf.ts
@@ -100,15 +100,12 @@ const convertHtmlToPdf = async (htmlFilePath: string, pdfFilePath: string): Prom
     await page.emulateMediaType("screen");
 
     // Replace local images with base64
-    const htmlContent = replaceSpecialCharacters(
-      await replaceLocalBackgroundImagesWithBase64InMemory(
-        replaceLocalImgSrcWithBase64(await fs.promises.readFile(htmlFilePath, "utf8")),
-        htmlFilePath
-      )
+    const htmlContent = await replaceLocalBackgroundImagesWithBase64InMemory(
+      replaceLocalImgSrcWithBase64(await fs.promises.readFile(htmlFilePath, "utf8")),
+      htmlFilePath
     );
 
     // Write the modified HTML content to a temporary file
-
     fs.writeFileSync(tempHtmlFilePath, htmlContent, "utf8");
 
     // Set content of the page to the temporary HTML file
@@ -250,15 +247,6 @@ const getImageMimeType = (imagePath: string): string => {
 
 const isExternalReference = (reference: string): boolean => {
   return /^(https?:)?\/\//i.test(reference);
-};
-
-const replaceSpecialCharacters = (input: string) => {
-  // Replace \" with "
-  // eslint-disable-next-line quotes
-  let result = input.replace(/\\"/g, '"');
-  // Remove \t and \n
-  result = result.replace(/\t|\n/g, "");
-  return result;
 };
 
 export default exportPdf;


### PR DESCRIPTION
# Why are you making this PR?
To fix the issue reported in #11, that fenced code blocks aren't displaying properly.

# What did you do?
- Removed a function that was removing spaces and tabs from the intermediary HTML (when exporting to PDF). These spaces and tabs are respected by the browser rendering the HTML (puppeteer/chrome) for the layout of the children `<code>`/`<pre>` tags, so keeping those characters in is necessary.
- Updated the version of the extension.
- Updated the changelog.