### PR TITLE
Extension Settings for Page Properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,31 +2,23 @@
 
 All notable changes to the "markdown-pdf-plus" extension will be documented in this file.
 
-## [1.0.0]
+## [1.2.5]
 
-- Initial release
+- Contributed settings for margins and page size.
 
-## [1.0.6]
+## [1.2.4]
 
-- Minimum VS Code version set to 1.76.0.
+- Fixed fenced code blocks.
 
-## [1.0.8]
+## [1.2.3]
 
-- [Fixed bug](https://github.com/ThomasLatham/markdown-pdf-plus/pull/3) causing `Markdown PDF Plus:
-  Export PDF` to fail in the absence of an internet connection.
-- Minimum VS Code version set to 1.75.0.
+- Background images are supported.
+- Broke fenced code blocks.
 
-## [1.1.0]
+## [1.2.2]
 
-- Using [Puppeteer Chromium Resolver](https://github.com/cenfun/puppeteer-chromium-resolver) to
-  resolve Chromium for `puppeteer.launch()`, in case user doesn't have
-  `C://Users/<user>/.cache/puppeteer` directory.
-- Updated the extension's icon for better visibility in the Marketplace and in the IDE.
-
-## [1.2.0]
-
-- [Mermaid](https://mermaid.js.org/) is supported.
-- Updated the README to include page-customization details.
+- ~~Background images are supported.~~
+- Still broken.
 
 ## [1.2.1]
 
@@ -36,16 +28,28 @@ All notable changes to the "markdown-pdf-plus" extension will be documented in t
 - ~~Exporting files to a specified directory now works even with referenced assets in the source file (e.g., CSS files and images).~~
 - Broke the extension.
 
-## [1.2.2]
+## [1.2.0]
 
-- ~~Background images are supported.~~
-- Still broken.
+- [Mermaid](https://mermaid.js.org/) is supported.
+- Updated the README to include page-customization details.
 
-## [1.2.3]
+## [1.1.0]
 
-- Background images are supported.
-- Broke fenced code blocks.
+- Using [Puppeteer Chromium Resolver](https://github.com/cenfun/puppeteer-chromium-resolver) to
+  resolve Chromium for `puppeteer.launch()`, in case user doesn't have
+  `C://Users/<user>/.cache/puppeteer` directory.
+- Updated the extension's icon for better visibility in the Marketplace and in the IDE.
 
-## [1.2.4]
+## [1.0.8]
 
-- Fixed fenced code blocks.
+- [Fixed bug](https://github.com/ThomasLatham/markdown-pdf-plus/pull/3) causing `Markdown PDF Plus:
+  Export PDF` to fail in the absence of an internet connection.
+- Minimum VS Code version set to 1.75.0.
+
+## [1.0.6]
+
+- Minimum VS Code version set to 1.76.0.
+
+## [1.0.0]
+
+- Initial release

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Export Markdown as PDF or HTML. Customize the output with CSS and images!
 
-## Features
+## Commands
 
 ### Export PDF
 
@@ -29,10 +29,30 @@ Demo:
 Demo: See the demo for Export PDF —— it's the same flow, except with the HTML command rather than
 the PDF one.
 
-### Page Customization (Margins, Page Breaks, Etc.)
+## Extension Settings
 
-Page properties of exported PDFs (e.g., margins, page size) can be customized via creating CSS that
-includes an
+This extension contributes the following settings:
+
+- `markdown-pdf-plus.marginTop`: The width* of the top margin of pages for exported PDFs.
+- `markdown-pdf-plus.marginBottom`: The width* of the bottom margin of pages for exported PDFs.
+- `markdown-pdf-plus.marginLeft`: The width* of the left margin of pages for exported PDFs.
+- `markdown-pdf-plus.marginRight`: The width* of the right margin of pages for exported PDFs.
+- `markdown-pdf-plus.pageSize`: The size of pages for exported PDFs. See the [documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/@page/size) for the size CSS at-rule descriptor, used with the `@page` at-rule, for more information.
+- `markdown-pdf-plus.outputHome`: The path of the directory where you wish your exported file to be
+  created (without trailing slash). If empty, defaults to the directory of the currently-open file
+  when a relevant command is called.
+- `markdown-pdf-plus.outputFilename`: The filename under which you wish your exported file to be
+  created (without any given extension). If empty, defaults to the name of your input file.
+- `markdown-pdf-plus.usePageStyleFromCSS`: Give any
+  [@page](https://developer.mozilla.org/en-US/docs/Web/CSS/@page) at-rule declared in CSS priority
+  over the extension's default page settings.
+
+*Available units include `px`, `cm` and `in`. See Mozilla's documentation on [length units](https://developer.mozilla.org/en-US/docs/Web/CSS/length#absolute_length_units) for more options
+
+## Page Customization (Margins, Page Breaks, Etc.)
+
+In lieu of using the contributed extension settings, page properties of exported PDFs (e.g.,
+margins, page size) can be customized via creating CSS that includes an 
 [@page](https://developer.mozilla.org/en-US/docs/Web/CSS/@page) at-rule and inserting that CSS into
 the PDF's source Markdown file. For a more detailed example please see [this
 answer](https://github.com/ThomasLatham/markdown-pdf-plus/issues/5#issuecomment-2180816708) to a related
@@ -44,18 +64,6 @@ desired. For reference please see [this
 answer](https://github.com/ThomasLatham/markdown-pdf-plus/issues/6#issuecomment-2111540362) to a
 related issue on this project's GitHub.
 
-## Extension Settings
-
-This extension contributes the following settings:
-
-- `markdown-pdf-plus.outputHome`: The path of the directory where you wish your exported file to be
-  created (without trailing slash). If empty, defaults to the directory of the currently-open file
-  when a relevant command is called.
-- `markdown-pdf-plus.outputFilename`: The filename under which you wish your exported file to be
-  created (without any given extension). If empty, defaults to the name of your input file.
-- `markdown-pdf-plus.usePageStyleFromCSS`: Give any
-  [@page](https://developer.mozilla.org/en-US/docs/Web/CSS/@page) at-rule declared in CSS priority
-  over the extension's default page settings.
 
 ## Known Issues
 

--- a/package.json
+++ b/package.json
@@ -61,8 +61,7 @@
         "markdown-pdf-plus.pageSize": {
           "type": "string",
           "default": "a4",
-          // TODO: add a link to available page sizes
-          "markdownDescription": "The size of the page. Available choices and descriptions can be found [here]()."
+          "markdownDescription": "The size of the page. See the [documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/@page/size) for the size CSS at-rule descriptor, used with the `@page` at-rule, for more information."
         },
         "markdown-pdf-plus.outputHome": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "markdown-pdf-plus.pageSize": {
           "type": "string",
           "default": "a4",
-          "markdownDescription": "The size of the page. See the [documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/@page/size) for the size CSS at-rule descriptor, used with the `@page` at-rule, for more information."
+          "markdownDescription": "The size of pages for exported PDFs. See the [documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/@page/size) for the size CSS at-rule descriptor, used with the `@page` at-rule, for more information."
         },
         "markdown-pdf-plus.outputHome": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -41,22 +41,22 @@
         "markdown-pdf-plus.marginTop": {
           "type": "string",
           "default": "70px",
-          "markdownDescription": "The width of the top margin of pages for exported PDFs."
+          "markdownDescription": "The width of the top margin of pages for exported PDFs. \n\n Available units include `px`, `cm` and `in`. See Mozilla's documentation on [length units](https://developer.mozilla.org/en-US/docs/Web/CSS/length#absolute_length_units) for more options."
         },
         "markdown-pdf-plus.marginBottom": {
           "type": "string",
           "default": "70px",
-          "markdownDescription": "The width of the bottom margin of pages for exported PDFs."
+          "markdownDescription": "The width of the bottom margin of pages for exported PDFs. \n\n Available units include `px`, `cm` and `in`. See Mozilla's documentation on [length units](https://developer.mozilla.org/en-US/docs/Web/CSS/length#absolute_length_units) for more options."
         },
         "markdown-pdf-plus.marginLeft": {
           "type": "string",
           "default": "70px",
-          "markdownDescription": "The width of the left margin of pages for exported PDFs."
+          "markdownDescription": "The width of the left margin of pages for exported PDFs. \n\n Available units include `px`, `cm` and `in`. See Mozilla's documentation on [length units](https://developer.mozilla.org/en-US/docs/Web/CSS/length#absolute_length_units) for more options."
         },
         "markdown-pdf-plus.marginRight": {
           "type": "string",
           "default": "70px",
-          "markdownDescription": "The width of the right margin of pages for exported PDFs."
+          "markdownDescription": "The width of the right margin of pages for exported PDFs. \n\n Available units include `px`, `cm` and `in`. See Mozilla's documentation on [length units](https://developer.mozilla.org/en-US/docs/Web/CSS/length#absolute_length_units) for more options."
         },
         "markdown-pdf-plus.pageSize": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-pdf-plus",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "publisher": "tom-latham",
   "engines": {
     "vscode": "^1.75.0"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,32 @@
     "configuration": {
       "title": "Markdown PDF Plus",
       "properties": {
+        "markdown-pdf-plus.marginTop": {
+          "type": "string",
+          "default": "70px",
+          "markdownDescription": "The width of the top margin of pages for exported PDFs."
+        },
+        "markdown-pdf-plus.marginBottom": {
+          "type": "string",
+          "default": "70px",
+          "markdownDescription": "The width of the bottom margin of pages for exported PDFs."
+        },
+        "markdown-pdf-plus.marginLeft": {
+          "type": "string",
+          "default": "70px",
+          "markdownDescription": "The width of the left margin of pages for exported PDFs."
+        },
+        "markdown-pdf-plus.marginRight": {
+          "type": "string",
+          "default": "70px",
+          "markdownDescription": "The width of the right margin of pages for exported PDFs."
+        },
+        "markdown-pdf-plus.pageSize": {
+          "type": "string",
+          "default": "a4",
+          // TODO: add a link to available page sizes
+          "markdownDescription": "The size of the page. Available choices and descriptions can be found [here]()."
+        },
         "markdown-pdf-plus.outputHome": {
           "type": "string",
           "default": "",

--- a/src/commands/export.pdf.ts
+++ b/src/commands/export.pdf.ts
@@ -249,4 +249,13 @@ const isExternalReference = (reference: string): boolean => {
   return /^(https?:)?\/\//i.test(reference);
 };
 
+/* We need a method that will write a `<style>` element into the HTML.
+ * This element will contain an `@page` rule with the details from the extension settings
+ * (i.e., margin-top, margin-bottom, margin-left, margin-right and size).
+ * Somehow it needs to have priority over any other ways these could be set (e.g.,
+ * in another style tag, in an external CSS sheet).
+ * Further, it should only set each property if there is a non-empty value for that property
+ * in the setting.
+ */
+
 export default exportPdf;

--- a/src/commands/export.pdf.ts
+++ b/src/commands/export.pdf.ts
@@ -99,11 +99,18 @@ const convertHtmlToPdf = async (htmlFilePath: string, pdfFilePath: string): Prom
     // Emulate screen media type to remove default header and footer
     await page.emulateMediaType("screen");
 
-    // Replace local images with base64
-    const htmlContent = await replaceLocalBackgroundImagesWithBase64InMemory(
-      replaceLocalImgSrcWithBase64(await fs.promises.readFile(htmlFilePath, "utf8")),
-      htmlFilePath
-    );
+    const htmlContent = 
+      // 4. add page style to the html content
+      await injectPageStyle(
+        // 3. replace local background images (CSS) with base64
+        await replaceLocalBackgroundImagesWithBase64InMemory(
+          // 2. replace local images (HTML) with base64
+          replaceLocalImgSrcWithBase64(
+            // 1. read the HTML content
+            await fs.promises.readFile(htmlFilePath, "utf8")),
+          htmlFilePath
+        )
+      );
 
     // Write the modified HTML content to a temporary file
     fs.writeFileSync(tempHtmlFilePath, htmlContent, "utf8");
@@ -249,13 +256,34 @@ const isExternalReference = (reference: string): boolean => {
   return /^(https?:)?\/\//i.test(reference);
 };
 
-/* We need a method that will write a `<style>` element into the HTML.
- * This element will contain an `@page` rule with the details from the extension settings
- * (i.e., margin-top, margin-bottom, margin-left, margin-right and size).
- * Somehow it needs to have priority over any other ways these could be set (e.g.,
- * in another style tag, in an external CSS sheet).
- * Further, it should only set each property if there is a non-empty value for that property
- * in the setting.
+/**
+ * Injects page style into the HTML content.
+ * @param htmlContent The HTML content to inject the page style into.
+ * @returns The HTML content with the injected page style.
  */
+const injectPageStyle = async (htmlContent: string): Promise<string> => {
+  const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("markdown-pdf-plus");
+
+  const marginTop = config.get("marginTop", "70px");
+  const marginBottom = config.get("marginBottom", "70px");
+  const marginLeft = config.get("marginLeft", "70px");
+  const marginRight = config.get("marginRight", "70px");
+  const pageSize = config.get("pageSize", "a4");
+
+  let styleContent = "@page {";
+
+  if (marginTop) styleContent += ` margin-top: ${marginTop};`;
+  if (marginBottom) styleContent += ` margin-bottom: ${marginBottom};`;
+  if (marginLeft) styleContent += ` margin-left: ${marginLeft};`;
+  if (marginRight) styleContent += ` margin-right: ${marginRight};`;
+  if (pageSize) styleContent += ` size: ${pageSize};`;
+
+  styleContent += " }";
+
+  const $ = load(htmlContent);
+  $("head").append(`<style>${styleContent}</style>`);
+
+  return $.html();
+};
 
 export default exportPdf;


### PR DESCRIPTION
# Why are you making this PR?
In order to address issue #15, by which the need was raised for the sake of user-friendliness to contribute settings to Markdown PDF Plus for customizing page properties of exported PDFs, especially margins.

# What did you do?
- Added settings to the manifest for page margins (top, bottom, left and right) as well as for page size (e.g., a4).
- Created and employed a new function in the export-PDF script which injects a `<style>` element with an `@page` at-rule containing users' preferences into the preprocessed HTML such that those preferences are reflected in the outputted HTML.
- Updated the README.
- Updated the CHANGELOG and restructured that file to be in reverse version order.
- Incremented the patch number.
- Performed regression testing to prevent breaking previous functionality with the addition of new functionality.